### PR TITLE
Fix: add pgvector vector extension creation

### DIFF
--- a/src/main/docker/postgresql.yml
+++ b/src/main/docker/postgresql.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   genie-postgresql:
-    image: ankane/pgvector
+    image: pgvector/pgvector:pg16
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/src/main/resources/config/liquibase/change-log-master.xml
+++ b/src/main/resources/config/liquibase/change-log-master.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <include file="config/liquibase/changelog/00000000000000_initial_schema.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20240117000000_created_vector_extension.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20240222085817_added_entity_Content.xml" relativeToChangelogFile="false"/>
     <include file="/config/liquibase/changelog/20240302085817_added_entity_Document_384.xml" relativeToChangelogFile="false"/>
     <include file="/config/liquibase/changelog/20240302085817_added_entity_Document_512.xml" relativeToChangelogFile="false"/>

--- a/src/main/resources/config/liquibase/changelog/20240117000000_created_vector_extension.xml
+++ b/src/main/resources/config/liquibase/changelog/20240117000000_created_vector_extension.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
     
-    <changeSet id="create-vector-extension" author="your_username">
+    <changeSet id="create-vector-extension" author="mmacphail">
         <sql>
             CREATE EXTENSION IF NOT EXISTS vector;
         </sql>

--- a/src/main/resources/config/liquibase/changelog/20240117000000_created_vector_extension.xml
+++ b/src/main/resources/config/liquibase/changelog/20240117000000_created_vector_extension.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    
+    <changeSet id="create-vector-extension" author="your_username">
+        <sql>
+            CREATE EXTENSION IF NOT EXISTS vector;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/devoxx/genie/config/ContainersConfig.java
+++ b/src/test/java/com/devoxx/genie/config/ContainersConfig.java
@@ -13,7 +13,7 @@ public class ContainersConfig {
     @ServiceConnection
     @RestartScope
     protected PostgreSQLContainer<?> postgreSQLContainer() {
-        var dockerImage = DockerImageName.parse("ankane/pgvector:v0.5.1")
+        var dockerImage = DockerImageName.parse("pgvector/pgvector:pg16")
             .asCompatibleSubstituteFor("postgres");
 
         var postgresContainer = new PostgreSQLContainer<>(dockerImage).withInitScript("init.sql");


### PR DESCRIPTION
Add the creation of the vector extension using liquibase when initializing the pgvector docker image as a liquibase changeset.

In the future, one would expect this extension to be automatically included in the docker image.

See this [issue](https://github.com/pgvector/pgvector/issues/512) for further information.