### PR TITLE
Fix: set user id when creating the chat bot

### DIFF
--- a/src/main/java/com/devoxx/genie/web/rest/ChatBotResource.java
+++ b/src/main/java/com/devoxx/genie/web/rest/ChatBotResource.java
@@ -71,7 +71,7 @@ public class ChatBotResource {
         User user = userService.getAdminUser()
             .orElseThrow(() ->
                 new BadRequestAlertException("USER_NOT_FOUND", "USER", "USER_NOT_FOUND_CODE"));
-
+        chatModelDTO.setUserId(user.getId());
 
         EmbeddingModel embeddingModel = embeddingModelService.getEmbeddingModelByUserIdAndRefId(user.getId(), chatModelDTO.getEmbeddingModelRefId())
             .orElseThrow(() -> new IllegalArgumentException("Embedding model not found"));


### PR DESCRIPTION
The user id is not propagated to the chatbot model, causing the app to fail when looking for the user's API Key.